### PR TITLE
feat: enable sourcemap in dev mode, minify code in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,15 +5,15 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "run-p dev:*",
-    "dev:prepare": "esno scripts/prepare.ts dev",
+    "dev": "cross-env NODE_ENV=development run-p dev:*",
+    "dev:prepare": "esno scripts/prepare.ts",
     "dev:web": "vite",
     "dev:js": "npm run build:js -- --watch src",
-    "build": "run-s clear build:web build:prepare build:js",
-    "build:prepare": "esno scripts/prepare.ts build",
+    "build": "cross-env NODE_ENV=production run-s clear build:web build:prepare build:js",
+    "build:prepare": "esno scripts/prepare.ts",
     "build:web": "vite build",
-    "build:js": "tsup src/background src/content --format iife --out-dir extension/dist --no-splitting",
-    "clear": "rimraf extension/dist"
+    "build:js": "tsup",
+    "clear": "rimraf extension/dist extension/manifest.json"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^0.7.0",
@@ -32,7 +32,7 @@
     "kolorist": "^1.5.0",
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.2",
-    "tsup": "^4.12.5",
+    "tsup": "^4.14.0",
     "typescript": "^4.3.5",
     "vite": "^2.4.3",
     "vite-plugin-components": "^0.13.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ specifiers:
   kolorist: ^1.5.0
   npm-run-all: ^4.1.5
   rimraf: ^3.0.2
-  tsup: ^4.12.5
+  tsup: ^4.14.0
   typescript: ^4.3.5
   vite: ^2.4.3
   vite-plugin-components: ^0.13.2
@@ -46,7 +46,7 @@ devDependencies:
   kolorist: 1.5.0
   npm-run-all: 4.1.5
   rimraf: 3.0.2
-  tsup: 4.12.5_typescript@4.3.5
+  tsup: 4.14.0_typescript@4.3.5
   typescript: 4.3.5
   vite: 2.4.3
   vite-plugin-components: 0.13.2_vite@2.4.3
@@ -2770,6 +2770,14 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /rollup/2.56.2:
+    resolution: {integrity: sha512-s8H00ZsRi29M2/lGdm1u8DJpJ9ML8SUOpVVBd33XNeEeL3NVaTiUcSBHzBdF3eAyR0l7VSpsuoVUGrRHq7aPwQ==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
   /run-parallel/1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -3074,8 +3082,8 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
-  /tsup/4.12.5_typescript@4.3.5:
-    resolution: {integrity: sha512-3f0StcX+trOZvgaY/iU11U8HvvQ4v/LLgoP9OmxtOQVXP8e/Q8FSk69d0bXFb2pHB77CmVxvqiWdwybELQfx1A==}
+  /tsup/4.14.0_typescript@4.3.5:
+    resolution: {integrity: sha512-77rWdzhikTP9mQ34XMRzK83tw++LF6f4ox/HNERlgesB7g6g5VQ1iJlueG9O0P9HAZGVKavUwyoZv0+322p6rg==}
     hasBin: true
     peerDependencies:
       typescript: ^4.2.3
@@ -3093,7 +3101,7 @@ packages:
       joycon: 3.0.1
       postcss-load-config: 3.1.0
       resolve-from: 5.0.0
-      rollup: 2.53.3
+      rollup: 2.56.2
       sucrase: 3.20.0
       tree-kill: 1.2.2
       typescript: 4.3.5
@@ -3249,6 +3257,21 @@ packages:
       vue: 3.1.5
     dev: true
 
+  /vue-demi/0.11.3_vue@3.1.5:
+    resolution: {integrity: sha512-DpM0TTMpclRZDV6AIacgg837zrim/C9Zn+2ztXBs9hsESJN9vC83ztjTe4KC4HgJuVle8YUjPp7HTwWtwOHfmg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+    dependencies:
+      vue: 3.1.5
+    dev: true
+
   /vue-eslint-parser/7.9.0_eslint@7.31.0:
     resolution: {integrity: sha512-QBlhZ5LteDRVy2dISfQhNEmmcqph+GTaD4SH41bYzXcVHFPJ9p34zCG6QAqOZVa8PKaVgbomFnoZpGJRZi14vg==}
     engines: {node: '>=8.10'}
@@ -3270,7 +3293,7 @@ packages:
   /vue-global-api/0.2.4_vue@3.1.5:
     resolution: {integrity: sha512-Cm84AZiALt8f4CJZzPvbForTzAUYe41msnzUnRK6B7YkaDaN8g87ap8CpHWvTU0+XtyDeLLAeQoRr+uwamxfpQ==}
     dependencies:
-      vue-demi: 0.11.2_vue@3.1.5
+      vue-demi: 0.11.3_vue@3.1.5
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -3,7 +3,7 @@ import { bgCyan, black } from 'kolorist'
 
 export const port = parseInt(process.env.PORT || '') || 3303
 export const r = (...args: string[]) => resolve(__dirname, '..', ...args)
-export const isDev = process.argv[2] === 'dev'
+export const isDev = process.env.NODE_ENV !== 'production'
 
 export function log(name: string, message: string) {
   // eslint-disable-next-line no-console

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,12 @@
+import type { Options } from 'tsup'
+
+const isDev = process.env.NODE_ENV !== 'production'
+
+export const tsup: Options = {
+  entryPoints: ['src/background', 'src/content'],
+  outDir: 'extension/dist',
+  format: ['iife'],
+  splitting: false,
+  sourcemap: isDev ? 'inline' : false,
+  minifyWhitespace: !isDev,
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ import WindiCSS from 'vite-plugin-windicss'
 import windiConfig from './windi.config'
 
 const port = parseInt(process.env.PORT || '') || 3303
+const isDev = process.env.NODE_ENV !== 'production'
 const r = (...args: string[]) => resolve(__dirname, ...args)
 
 export default defineConfig(({ command }) => {
@@ -27,6 +28,11 @@ export default defineConfig(({ command }) => {
     build: {
       outDir: r('extension/dist'),
       emptyOutDir: false,
+      sourcemap: isDev ? 'inline' : false,
+      // https://developer.chrome.com/docs/webstore/program_policies/#:~:text=Code%20Readability%20Requirements
+      terserOptions: {
+        mangle: false,
+      },
       rollupOptions: {
         input: {
           popup: r('views/popup/index.html'),


### PR DESCRIPTION
Enable sourcemap in dev mode for a better debug experience.
Minify(without mangle) code in production mode.

Relevance:
* https://github.com/antfu/vitesse-webext/pull/7
* https://github.com/antfu/vitesse-webext/issues/8