### PR TITLE
fix: capture example error

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,5 +1,5 @@
 import { sendMessage, onMessage } from 'webext-bridge'
-import { browser } from 'webextension-polyfill-ts'
+import { browser, Tabs } from 'webextension-polyfill-ts'
 
 browser.runtime.onInstalled.addListener((): void => {
   // eslint-disable-next-line no-console
@@ -9,16 +9,21 @@ browser.runtime.onInstalled.addListener((): void => {
 let previousTabId = 0
 
 // communication example: send previous tab title from background page
-// see shim.d.ts for type decleration
+// see shim.d.ts for type declaration
 browser.tabs.onActivated.addListener(async({ tabId }) => {
   if (!previousTabId) {
     previousTabId = tabId
     return
   }
-  const tab = await browser.tabs.get(previousTabId)
-  previousTabId = tabId
-  if (!tab)
+
+  let tab: Tabs.Tab
+
+  try {
+    tab = await browser.tabs.get(previousTabId)
+    previousTabId = tabId
+  } catch {
     return
+  }
 
   // eslint-disable-next-line no-console
   console.log('previous tab', tab)


### PR DESCRIPTION
When closing a tab, the `previousTabId` point to a non-exist tab, and then the `browser.tabs.get` will throw an error.