### PR TITLE
fix: reload manifest.ts module on watch

### DIFF
--- a/scripts/prepare.ts
+++ b/scripts/prepare.ts
@@ -1,7 +1,6 @@
 // generate stub index.html files for dev entry
 import fs from 'fs-extra'
 import chokidar from 'chokidar'
-import { getManifest } from '../src/manifest'
 import { r, port, isDev, log } from './utils'
 
 /**
@@ -26,6 +25,7 @@ async function stubIndexHtml() {
 }
 
 export async function writeManifest() {
+  const { getManifest } = await import(r('src/manifest.ts'))
   await fs.writeJSON(r('extension/manifest.json'), await getManifest(), { spaces: 2 })
   log('PRE', 'write manifest.json')
 }
@@ -40,6 +40,7 @@ if (isDev) {
     })
   chokidar.watch([r('src/manifest.ts'), r('package.json')])
     .on('change', () => {
+      delete require.cache[r('src/manifest.ts')]
       writeManifest()
     })
 }


### PR DESCRIPTION
Modules are only evaluated once so the script was always using a "stale" version of `getManifest` (the one that got loaded during its initialization). By removing that entry from the `require.cache` I allow this module to be re-executed whenever it changes and thus a new, fresh, version of `getManifest` has a chance to be executed.

⚠️ This simplistic solution has a caveat - dependencies of `manifest.ts` won't be reloaded so technically you can still end up with stale manifests. I have wanted to avoid bundling this and I think that this will work for the majority of use cases - if you have a better idea I'm open to revisiting this.