### PR TITLE
feat: base _blank to open links in new window

### DIFF
--- a/src/options/index.html
+++ b/src/options/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <base target="_blank">
   <title>Options</title>
 </head>
 <body>

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <base target="_blank">
   <title>Popup</title>
 </head>
 <body style="min-width: 100px">


### PR DESCRIPTION
## Problem
Options and Popup pages cannot have links that open in the same window. However, there are no errors if your links are missing `target="_blank"`.

## Changes
Default all links to open in a new window/tab via `<base target="_blank">`.