### PR TITLE
fix: ts not assignable

### DIFF
--- a/shim.d.ts
+++ b/shim.d.ts
@@ -5,6 +5,6 @@ declare module 'webext-bridge' {
     // define message protocol types
     // see https://github.com/antfu/webext-bridge#type-safe-protocols
     'tab-prev': { title: string | undefined }
-    'get-current-tab': ProtocolWithReturn<{ tabId: number }, { title: string }>
+    'get-current-tab': ProtocolWithReturn<{ tabId: number }, { title?: string }>
   }
 }

--- a/src/background/main.ts
+++ b/src/background/main.ts
@@ -43,7 +43,7 @@ onMessage('get-current-tab', async() => {
   try {
     const tab = await browser.tabs.get(previousTabId)
     return {
-      title: tab?.id,
+      title: tab?.title,
     }
   }
   catch {


### PR DESCRIPTION
`onMessage`'s call signature was fixed in https://github.com/antfu/webext-bridge/commit/127395fc4ab058139c6b7826b8966a0102b5bbe9#diff-f200c59206c76dbdfbf32fc10332254fefa285b93bb6abcf57ab84b0013d45d5R10