### PR TITLE
fix: unspecify includes in contentscript watch

### DIFF
--- a/vite.config.content.ts
+++ b/vite.config.content.ts
@@ -10,12 +10,7 @@ export default defineConfig({
   ...sharedConfig,
   build: {
     watch: isDev
-      ? {
-        include: [
-          r('src/contentScripts/**/*'),
-          r('src/components/**/*'),
-        ],
-      }
+      ? {}
       : undefined,
     outDir: r('extension/dist/contentScripts'),
     cssCodeSplit: false,


### PR DESCRIPTION
## Problem
Vite watch only triggered a re-build when files in `build.watch.include` changed. That means changes in shared logic outside of those globs were not detected despite being in the dependency tree.

## Changes
Passing in an empty object and not defining `include` let rollup automatically determine the exact files in the dependency tree that it should watch.

This now rebuilds on any change that are imported.
