### PR TITLE
fix: pack the correct .zip file

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:web": "vite build",
     "build:js": "vite build --config vite.config.content.ts",
     "pack": "cross-env NODE_ENV=production run-p pack:*",
-    "pack:zip": "rimraf extension.zip && jszip-cli add extension -o ./extension.zip",
+    "pack:zip": "rimraf extension.zip && jszip-cli add extension/* -o ./extension.zip",
     "pack:crx": "crx pack extension -o ./extension.crx",
     "pack:xpi": "cross-env WEB_EXT_ARTIFACTS_DIR=./ web-ext build --source-dir ./extension --filename extension.xpi --overwrite-dest",
     "start:chromium": "web-ext run --source-dir ./extension --target=chromium",


### PR DESCRIPTION
The content of the extension should be zipped directly so that it can be loaded by Chrome, otherwise, users should unzip it and load the `extension` folder inside the zip.