### PR TITLE
remove illegal colons in path names on Windows

### DIFF
--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -4,6 +4,7 @@ import { bgCyan, black } from 'kolorist'
 export const port = parseInt(process.env.PORT || '') || 3303
 export const r = (...args: string[]) => resolve(__dirname, '..', ...args)
 export const isDev = process.env.NODE_ENV !== 'production'
+export const isWin = process.platform === "win32";
 
 export function log(name: string, message: string) {
   // eslint-disable-next-line no-console

--- a/vite-mv3-hmr.ts
+++ b/vite-mv3-hmr.ts
@@ -1,7 +1,7 @@
 import { dirname, join } from 'path'
 import type { HMRPayload, PluginOption } from 'vite'
 import fs from 'fs-extra'
-import { r } from './scripts/utils'
+import { r, isWin } from './scripts/utils'
 
 const targetDir = r('extension')
 
@@ -48,7 +48,10 @@ export const MV3Hmr = (): PluginOption => {
 
         if (importedModules) {
           for (const mod of importedModules) {
-            code = code.replace(mod.url, normalizeViteUrl(mod.url, mod.type))
+            code = code.replace(mod.url, normalizeViteUrl(isWin
+              ? mod.url.replace(/[A-Z]:\//,'').replace(/:/,'.')
+              : mod.url,
+              mod.type)) // fix invalid colon in /@fs/C:, /@id/plugin-vue:export-helper
             writeToDisk(mod.url)
           }
         }
@@ -57,8 +60,15 @@ export const MV3Hmr = (): PluginOption => {
           code = code
             .replace(/\/@vite\/client/g, '/dist/mv3client.mjs')
             .replace(/(\/\.vite\/deps\/\S+?)\?v=\w+/g, '$1')
+          if (isWin) { code = code
+            .replace(/(from\s+["']\/@fs\/)[A-Z]:\//g, '$1')
+          };
 
-          const targetFile = normalizeFsUrl(urlModule.url, urlModule.type)
+
+          const targetFile = normalizeFsUrl(isWin
+            ? urlModule.url.replace(/[A-Z]:\//,'').replace(/:/,'.')
+            : urlModule.url,
+            urlModule.type) // fix invalid colon in /@fs/C:, /@id/plugin-vue:export-helper
           await fs.ensureDir(dirname(targetFile))
           await fs.writeFile(targetFile, code)
         }


### PR DESCRIPTION
Dev mode of MV3 fails on Windows due to illegal colons `:` in paths, e.g., `/@fs/C:/` or `/@id/plugin-vue:export-helper`
This PR removes the `C:/` and replaces other colons in paths and `from` import fields with a period

Addresses one of the issues raised [here](https://github.com/antfu/vitesse-webext/issues/59) in [this comment](https://github.com/antfu/vitesse-webext/issues/59#issuecomment-1134116651)

Checked on Windows and a Mac, Windows seems to be working fine, Mac has an `unplugin-icons` error on rebuild (might be an issue with it not knowing about `@id` prefix), but this error is also present without this PR 