### PR TITLE
fix: @vueuse/core not export StorageAsyncOptions type, the correct is UseS…

### DIFF
--- a/src/composables/useStorageLocal.ts
+++ b/src/composables/useStorageLocal.ts
@@ -2,8 +2,8 @@ import { storage } from 'webextension-polyfill'
 import type {
   MaybeRef,
   RemovableRef,
-  StorageAsyncOptions,
   StorageLikeAsync,
+  UseStorageAsyncOptions,
 } from '@vueuse/core'
 import {
   useStorageAsync,
@@ -26,5 +26,5 @@ const storageLocal: StorageLikeAsync = {
 export const useStorageLocal = <T>(
   key: string,
   initialValue: MaybeRef<T>,
-  options?: StorageAsyncOptions<T>,
+  options?: UseStorageAsyncOptions<T>,
 ): RemovableRef<T> => useStorageAsync(key, initialValue, storageLocal, options)


### PR DESCRIPTION
…torageAsyncOptions

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
In the useStorageLocal.ts file, my vscode prompts me that StorageAsyncOptions is wrong, probably UseStorageAsyncOptions
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
