### PR TITLE
chore: remove `listenToStorageChanges: true`. It's true by default.

### DIFF
--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -1,3 +1,3 @@
 import { useStorageLocal } from '~/composables/useStorageLocal'
 
-export const storageDemo = useStorageLocal('webext-demo', 'Storage Demo', { listenToStorageChanges: true })
+export const storageDemo = useStorageLocal('webext-demo', 'Storage Demo')


### PR DESCRIPTION
### Description

We don't need to set `listenToStorageChanges: true` as it's already by default. 
`useStorageLocal` use vueUse `useStorageAsync` under the hood. [Here the default value in useStorage](https://github.com/vueuse/vueuse/blob/main/packages/core/useStorage/index.ts#L128).