### PR TITLE
fix(pkg): add --glob flag to clear script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "pack:xpi": "cross-env WEB_EXT_ARTIFACTS_DIR=./ web-ext build --source-dir ./extension --filename extension.xpi --overwrite-dest",
     "start:chromium": "web-ext run --source-dir ./extension --target=chromium",
     "start:firefox": "web-ext run --source-dir ./extension --target=firefox-desktop",
-    "clear": "rimraf extension/dist extension/manifest.json extension.*",
+    "clear": "rimraf --glob extension/dist extension/manifest.json extension.*",
     "lint": "eslint --cache .",
     "test": "vitest test",
     "postinstall": "simple-git-hooks"


### PR DESCRIPTION
> vitesse-webext@0.0.1 clear C:\Users\willi\code\extensions\vitesse-webext
> rimraf --glob extension/dist extension/manifest.json extension.* script

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Currently, running `pnpm dev` or `pnpm build` scripts fail with the following error:

```sh
$ pnpm dev

> vitesse-webext@0.0.1 dev C:\Users\willi\code\extensions\vitesse-webext
> npm run clear && cross-env NODE_ENV=development run-p dev:*


> vitesse-webext@0.0.1 clear
> rimraf extension/dist extension/manifest.json extension.*

Error: Illegal characters in path.
    at pathArg (C:\Users\willi\code\extensions\vitesse-webext\node_modules\.pnpm\rimraf@4.3.0\node_modules\rimraf\dist\cjs\src\path-arg.js:45:33)
    at C:\Users\willi\code\extensions\vitesse-webext\node_modules\.pnpm\rimraf@4.3.0\node_modules\rimraf\dist\cjs\src\index.js:40:80
    at Array.map (<anonymous>)
    at C:\Users\willi\code\extensions\vitesse-webext\node_modules\.pnpm\rimraf@4.3.0\node_modules\rimraf\dist\cjs\src\index.js:40:42
    at main (C:\Users\willi\code\extensions\vitesse-webext\node_modules\.pnpm\rimraf@4.3.0\node_modules\rimraf\dist\cjs\src\bin.js:245:15)
    at Object.<anonymous> (C:\Users\willi\code\extensions\vitesse-webext\node_modules\.pnpm\rimraf@4.3.0\node_modules\rimraf\dist\cjs\src\bin.js:255:5)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12) {
  path: 'C:\\Users\\willi\\code\\extensions\\vitesse-webext\\extension.*',
  code: 'EINVAL'
}
 ELIFECYCLE  Command failed with exit code 1.
```

This is due to a missing `--glob` flag when running the `clear` script which runs `rimraf`.

Adding `--glob` to script resolves the error and `build` and `dev` scripts both work after fix.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

n/a - figured it was simple enough to just PR for this fix, since it's just one line 👨🏼‍💻 

### Additional context

Here is a [stackoverflow post](https://stackoverflow.com/questions/75281066/error-illegal-characters-in-path-in-npm-rimraf) which led me to this solution.   

<!-- e.g. is there anything you'd like reviewers to focus on? -->
