### PR TITLE
fix: add build:background to build workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev:background": "npm run build:background -- --mode development",
     "dev:web": "vite",
     "dev:js": "npm run build:js -- --mode development",
-    "build": "cross-env NODE_ENV=production run-s clear build:web build:prepare build:js",
+    "build": "cross-env NODE_ENV=production run-s clear build:web build:prepare build:background build:js",
     "build:prepare": "esno scripts/prepare.ts",
     "build:background": "vite build --config vite.config.background.ts",
     "build:web": "vite build",


### PR DESCRIPTION
### Description

The `build:background` is missing in `build` script.

maybe we can simplify this later.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
