### PR TITLE
fix: change background script to .mjs extension

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -22,7 +22,7 @@ export async function getManifest() {
       open_in_tab: true,
     },
     background: {
-      service_worker: './dist/background/index.js',
+      service_worker: './dist/background/index.mjs',
     },
     icons: {
       16: './assets/icon-512.png',

--- a/vite.config.background.ts
+++ b/vite.config.background.ts
@@ -27,7 +27,7 @@ export default defineConfig({
     },
     rollupOptions: {
       output: {
-        entryFileNames: 'index.js',
+        entryFileNames: 'index.mjs',
         extend: true,
       },
     },


### PR DESCRIPTION
### Description

change the extension of background script to .mjs, as it's in esm format.

### Linked Issues

close #128

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
