### PR TITLE
fix: support firefox background script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "description": "[description]",
   "scripts": {
     "dev": "npm run clear && cross-env NODE_ENV=development run-p dev:*",
+    "dev-firefox": "npm run clear && cross-env NODE_ENV=development EXTENSION=firefox run-p dev:*",
     "dev:prepare": "esno scripts/prepare.ts",
     "dev:background": "npm run build:background -- --mode development",
     "dev:web": "vite",

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -4,6 +4,7 @@ import { bgCyan, black } from 'kolorist'
 export const port = parseInt(process.env.PORT || '') || 3303
 export const r = (...args: string[]) => resolve(__dirname, '..', ...args)
 export const isDev = process.env.NODE_ENV !== 'production'
+export const isFirefox = process.env.EXTENSION === 'firefox'
 
 export function log(name: string, message: string) {
   console.log(black(bgCyan(` ${name} `)), message)

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra'
 import type { Manifest } from 'webextension-polyfill'
 import type PkgType from '../package.json'
-import { isDev, port, r } from '../scripts/utils'
+import { isDev, isFirefox, port, r } from '../scripts/utils'
 
 export async function getManifest() {
   const pkg = await fs.readJSON(r('package.json')) as typeof PkgType
@@ -21,9 +21,14 @@ export async function getManifest() {
       page: './dist/options/index.html',
       open_in_tab: true,
     },
-    background: {
-      service_worker: './dist/background/index.mjs',
-    },
+    background: isFirefox
+      ? {
+          scripts: ['dist/background/index.mjs'],
+          type: 'module',
+        }
+      : {
+          service_worker: './dist/background/index.mjs',
+        },
     icons: {
       16: './assets/icon-512.png',
       48: './assets/icon-512.png',


### PR DESCRIPTION
### Description
Firefox doesn't support `background.service_worker` and wants `background.scripts` in manifest v3 version


### Linked Issues


### Additional context
