### PR TITLE
Adding an option to develop in the cloud using Gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,7 @@
+FROM gitpod/workspace-full-vnc
+
+USER root
+
+# Install dependencies
+RUN apt-get update                                            \
+    && apt-get install -y firefox

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,23 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: pnpm install && pnpm run build
+    name: dev
+    command: |
+      gp sync-done ready
+      pnpm run dev
+  - name: pnpm start:chromium
+    command: |
+      gp sync-await ready
+      gp ports await 6080
+      gp preview $(gp url 6080)
+      sleep 5
+      pnpm start:chromium
+    openMode: split-right
+
+ports:
+  - port: 5900
+    onOpen: ignore
+  - port: 6080
+    onOpen: ignore

--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ pnpm start:firefox
 
 > While Vite handles HMR automatically in the most of the case, [Extensions Reloader](https://chrome.google.com/webstore/detail/fimgfedafeadlieiabdeeaodndnlbhid) is still recommanded for cleaner hard reloading.
 
+## Using Gitpod
+
+If you have a web browser, you can get a fully pre-configured development environment with one click:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/antfu/vitesse-webext)
+
 ### Build
 
 To build the extension, run


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR adds the ability to develop `vitesse-webext` project in the cloud using Gitpod.

You can try it here:
https://gitpod.io/#https://github.com/antfu/vitesse-webext/pull/161