### PR TITLE
fix: use localhost as base in dev mode

### DIFF
--- a/scripts/prepare.ts
+++ b/scripts/prepare.ts
@@ -19,6 +19,7 @@ async function stubIndexHtml() {
     let data = await fs.readFile(r(`src/${view}/index.html`), 'utf-8')
     data = data
       .replace('"./main.ts"', `"http://localhost:${port}/${view}/main.ts"`)
+      .replace('<base target="_blank">', `<base target="_blank" href="http://localhost:${port}/">`)
       .replace('<div id="app"></div>', '<div id="app">Vite server did not start</div>')
     await fs.writeFile(r(`extension/dist/${view}/index.html`), data, 'utf-8')
     log('PRE', `stub ${view}`)


### PR DESCRIPTION
### Description

it should be localhost as expected, but the host was trimmed, not intuitive 🤔:
https://github.com/antfu/vitesse-webext/blob/713d7ee0318dfcb88ade3c983919fc828c39ef66/vite.config.ts#L84

### Linked Issues

close #156 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
