### PR TITLE
fix: remove leading './' from manifest paths

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -14,11 +14,11 @@ export async function getManifest() {
     version: pkg.version,
     description: pkg.description,
     action: {
-      default_icon: './assets/icon-512.png',
-      default_popup: './dist/popup/index.html',
+      default_icon: 'assets/icon-512.png',
+      default_popup: 'dist/popup/index.html',
     },
     options_ui: {
-      page: './dist/options/index.html',
+      page: 'dist/options/index.html',
       open_in_tab: true,
     },
     background: isFirefox
@@ -27,12 +27,12 @@ export async function getManifest() {
           type: 'module',
         }
       : {
-          service_worker: './dist/background/index.mjs',
+          service_worker: 'dist/background/index.mjs',
         },
     icons: {
-      16: './assets/icon-512.png',
-      48: './assets/icon-512.png',
-      128: './assets/icon-512.png',
+      16: 'assets/icon-512.png',
+      48: 'assets/icon-512.png',
+      128: 'assets/icon-512.png',
     },
     permissions: [
       'tabs',


### PR DESCRIPTION
### Description
This PR fixes an issue where the Chrome Web Store was rejecting the extension due to path formatting in the manifest.json file. The issue was caused by paths starting with `./` which Chrome doesn't expect in manifest paths.


<img width="542" alt="Screenshot 2025-07-04 at 17 23 22" src="https://github.com/user-attachments/assets/4de8c508-46a6-40f1-b9dc-a8ce8ea5d5d9" />
